### PR TITLE
refactor(test): remove workaround for jest 24

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,11 +1,5 @@
 'use strict';
 
-/*
- * @todo Remove jest workaround from test.js
- * @body This workaround was added because of a problem with using jest 24 programmatically. See https://github.com/facebook/jest/issues/7704
- */
-require('jest/node_modules/jest-cli/build/cli');
-
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'test';
 process.env.NODE_ENV = 'test';


### PR DESCRIPTION
The workaround was needed because jest 24.0 had a dependency cycle and
therefore was problematic to import and use programatically.
See https://github.com/facebook/jest/issues/7704.

This closes #25.